### PR TITLE
Update index.toc to include link to "Testing with compile-time Dependency Injection"

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/index.toc
+++ b/documentation/manual/working/scalaGuide/main/tests/index.toc
@@ -4,5 +4,6 @@ ScalaFunctionalTestingWithScalaTest:Writing functional tests with ScalaTest
 ScalaTestingWithSpecs2:Testing with specs2
 ScalaFunctionalTestingWithSpecs2:Writing functional tests with specs2
 ScalaTestingWithGuice:Testing with Guice
+ScalaTestingWithComponents:Testing with compile-time Dependency Injection
 ScalaTestingWithDatabases:Testing with databases
 ScalaTestingWebServiceClients:Testing web service clients


### PR DESCRIPTION

Update index.toc to include link to `Testing with compile-time Dependency Injection` in the scalatestplus-play repo.

This documentation covers the new test classes to support those who aren't using Guice.


## References
See: https://github.com/playframework/scalatestplus-play/pull/85
